### PR TITLE
Release JellyBulletin 0.3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to JellyBulletin are documented here.
 
+## 0.3.15.0 — Public beta
+
+- Present the plugin logo on a centered 16:9 catalog canvas with safe spacing.
+
 ## 0.3.14.0 — Public beta
 
 - Add Compact, Standard and Tall announcement panel heights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to JellyBulletin are documented here.
 
+## 0.3.14.0 — Public beta
+
+- Add Compact, Standard and Tall announcement panel heights.
+- Apply the selected height consistently to the carousel and live preview.
+- Preserve Standard as the default for existing installations.
+
 ## 0.3.13.0 — Public beta
 
 - Preserve bullet and numbered lists nested inside browser-generated wrappers.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.14.0</Version>
-    <AssemblyVersion>0.3.14.0</AssemblyVersion>
-    <FileVersion>0.3.14.0</FileVersion>
+    <Version>0.3.15.0</Version>
+    <AssemblyVersion>0.3.15.0</AssemblyVersion>
+    <FileVersion>0.3.15.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.13.0</Version>
-    <AssemblyVersion>0.3.13.0</AssemblyVersion>
-    <FileVersion>0.3.13.0</FileVersion>
+    <Version>0.3.14.0</Version>
+    <AssemblyVersion>0.3.14.0</AssemblyVersion>
+    <FileVersion>0.3.14.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.JellyBulletin/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyBulletin/Configuration/PluginConfiguration.cs
@@ -18,6 +18,11 @@ public sealed class PluginConfiguration : BasePluginConfiguration
     public int VisibleItemCount { get; set; } = 5;
 
     /// <summary>
+    /// Gets or sets the home-screen announcement panel height.
+    /// </summary>
+    public string PanelHeight { get; set; } = "standard";
+
+    /// <summary>
     /// Gets or sets a value indicating whether announcements rotate automatically.
     /// </summary>
     public bool AutoRotate { get; set; } = true;

--- a/Jellyfin.Plugin.JellyBulletin/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyBulletin/Configuration/configPage.html
@@ -17,6 +17,16 @@
                     </select>
                 </div>
 
+                <div class="selectContainer">
+                    <label class="selectLabel" for="BulletinPanelHeight">Announcement panel height</label>
+                    <select id="BulletinPanelHeight" is="emby-select" class="emby-select-withcolor emby-select">
+                        <option value="compact">Compact</option>
+                        <option value="standard">Standard</option>
+                        <option value="tall">Tall</option>
+                    </select>
+                    <div class="fieldDescription">Controls the height of the complete announcement panel for every user.</div>
+                </div>
+
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
                         <input id="BulletinAutoRotate" type="checkbox" is="emby-checkbox" />
@@ -217,6 +227,8 @@
         .bulletin-preview-label h2 { margin:0; font-size:1rem; }
         .bulletin-preview-label span { opacity:.58; font-size:.8rem; }
         .bulletin-preview-feature { display:grid; grid-template-columns:minmax(0,1fr); width:100%; aspect-ratio:45 / 11; overflow:hidden; }
+        .bulletin-preview-feature.height-compact { aspect-ratio:5 / 1; }
+        .bulletin-preview-feature.height-tall { aspect-ratio:13 / 4; }
         .bulletin-preview-feature.has-image { grid-template-columns:minmax(0,1.25fr) minmax(15rem,.75fr); }
         .bulletin-preview-copy { min-width:0; overflow:hidden; padding:1rem 1.2rem; scrollbar-width:thin; }
         .bulletin-preview-copy h3 { margin:0 0 .15rem; font-size:1.25rem; line-height:1.15; }
@@ -234,8 +246,8 @@
         .bulletin-editor-actions { display:flex; gap:.75rem; margin:1rem 0 2rem; }
         .bulletin-schedule-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; }
         .bulletin-datetime-input { box-sizing:border-box; width:100%; min-height:2.8rem; padding:.55rem .7rem; border:1px solid var(--jf-palette-divider,rgba(255,255,255,.2)); border-radius:.25rem; background:var(--jf-palette-background-paper,rgba(255,255,255,.14)); color:inherit; }
-        @media(max-width:850px) { .bulletin-preview-feature.has-image { grid-template-columns:1fr; aspect-ratio:auto; height:27rem; } .bulletin-home-image-preview-frame { order:-1; width:calc(100% - .8rem); height:9.2rem; margin:.4rem; border-radius:.35rem; } .bulletin-home-image-preview { border-radius:.3rem; } }
-        @media(max-width:700px) { .bulletin-admin-layout { grid-template-columns:1fr; } .bulletin-preview-feature { aspect-ratio:auto; height:27rem; } .bulletin-preview-label { align-items:flex-start; flex-direction:column; gap:.15rem; } .bulletin-schedule-grid { grid-template-columns:1fr; } }
+        @media(max-width:850px) { .bulletin-preview-feature.has-image { grid-template-columns:1fr; aspect-ratio:auto; height:27rem; } .bulletin-preview-feature.height-compact { height:21rem; } .bulletin-preview-feature.height-tall { height:34rem; } .bulletin-home-image-preview-frame { order:-1; width:calc(100% - .8rem); height:9.2rem; margin:.4rem; border-radius:.35rem; } .bulletin-home-image-preview { border-radius:.3rem; } }
+        @media(max-width:700px) { .bulletin-admin-layout { grid-template-columns:1fr; } .bulletin-preview-feature { aspect-ratio:auto; height:27rem; } .bulletin-preview-feature.height-compact { height:21rem; } .bulletin-preview-feature.height-tall { height:34rem; } .bulletin-preview-label { align-items:flex-start; flex-direction:column; gap:.15rem; } .bulletin-schedule-grid { grid-template-columns:1fr; } }
     </style>
 
     <script type="text/javascript">
@@ -279,6 +291,8 @@
             const validImageUrl = url =>
                 /^https?:\/\//i.test(url || '')
                 || /^\/Bulletin\/Image\/[0-9a-f]{32}\.(png|jpg|webp)$/i.test(url || '');
+            const normalizePanelHeight = height =>
+                height === 'compact' || height === 'tall' ? height : 'standard';
 
             function normalizeInline(run) {
                 return {
@@ -364,6 +378,11 @@
                 }).format(new Date(published));
 
                 const editor = page.querySelector('#BulletinEditor');
+                const previewFeature = page.querySelector('#BulletinPreviewFeature');
+                const panelHeight = normalizePanelHeight(
+                    page.querySelector('#BulletinPanelHeight').value);
+                previewFeature.classList.remove('height-compact', 'height-standard', 'height-tall');
+                previewFeature.classList.add(`height-${panelHeight}`);
                 const previewBody = page.querySelector('#BulletinPreviewBody');
                 previewBody.replaceChildren(...[...editor.childNodes].map(node => node.cloneNode(true)));
                 if (!previewBody.textContent.trim()) {
@@ -374,7 +393,6 @@
                 }
 
                 const imageUrl = page.querySelector('#BulletinImageUrl').value.trim();
-                const previewFeature = page.querySelector('#BulletinPreviewFeature');
                 const previewImageFrame = page.querySelector('#BulletinHomeImagePreviewFrame');
                 const previewImage = page.querySelector('#BulletinHomeImagePreview');
                 if (validImageUrl(imageUrl)) {
@@ -714,6 +732,8 @@
                     items = (value(response, 'Items', 'items') || []).map(normalizeItem);
                     page.querySelector('#BulletinVisibleCount').value =
                         String(value(response, 'VisibleItemCount', 'visibleItemCount') || 5);
+                    page.querySelector('#BulletinPanelHeight').value = normalizePanelHeight(
+                        value(response, 'PanelHeight', 'panelHeight'));
                     page.querySelector('#BulletinAutoRotate').checked =
                         Boolean(value(response, 'AutoRotate', 'autoRotate') ?? true);
                     page.querySelector('#BulletinRotationInterval').value =
@@ -786,6 +806,7 @@
                 updateHomePreview();
             });
             page.querySelector('#BulletinTitle').addEventListener('input', updateHomePreview);
+            page.querySelector('#BulletinPanelHeight').addEventListener('change', updateHomePreview);
             page.querySelector('#BulletinImageAlt').addEventListener('input', updateHomePreview);
             page.querySelector('#BulletinEditor').addEventListener('input', updateHomePreview);
             page.querySelector('#BulletinPublishAt').addEventListener('input', updateHomePreview);
@@ -896,6 +917,7 @@
                 try {
                     const payload = {
                         VisibleItemCount: Number(page.querySelector('#BulletinVisibleCount').value),
+                        PanelHeight: normalizePanelHeight(page.querySelector('#BulletinPanelHeight').value),
                         AutoRotate: page.querySelector('#BulletinAutoRotate').checked,
                         RotationIntervalSeconds: Number(page.querySelector('#BulletinRotationInterval').value),
                         Items: items

--- a/Jellyfin.Plugin.JellyBulletin/Models/BulletinModels.cs
+++ b/Jellyfin.Plugin.JellyBulletin/Models/BulletinModels.cs
@@ -67,6 +67,8 @@ public sealed class SaveBulletinsRequest
 {
     public int VisibleItemCount { get; set; } = 5;
 
+    public string PanelHeight { get; set; } = "standard";
+
     public bool AutoRotate { get; set; } = true;
 
     public int RotationIntervalSeconds { get; set; } = 9;
@@ -80,6 +82,8 @@ public sealed class SaveBulletinsRequest
 public sealed class BulletinResponse
 {
     public int VisibleItemCount { get; set; }
+
+    public string PanelHeight { get; set; } = "standard";
 
     public bool AutoRotate { get; set; }
 

--- a/Jellyfin.Plugin.JellyBulletin/Services/BulletinStore.cs
+++ b/Jellyfin.Plugin.JellyBulletin/Services/BulletinStore.cs
@@ -37,6 +37,7 @@ public sealed partial class BulletinStore
         return new BulletinResponse
         {
             VisibleItemCount = Math.Clamp(configuration.VisibleItemCount, 3, 5),
+            PanelHeight = NormalizePanelHeight(configuration.PanelHeight),
             AutoRotate = configuration.AutoRotate,
             RotationIntervalSeconds = Math.Clamp(configuration.RotationIntervalSeconds, 5, 30),
             Items = items
@@ -48,6 +49,7 @@ public sealed partial class BulletinStore
         return new SaveBulletinsRequest
         {
             VisibleItemCount = Math.Clamp(Plugin.Instance.Configuration.VisibleItemCount, 3, 5),
+            PanelHeight = NormalizePanelHeight(Plugin.Instance.Configuration.PanelHeight),
             AutoRotate = Plugin.Instance.Configuration.AutoRotate,
             RotationIntervalSeconds = Math.Clamp(Plugin.Instance.Configuration.RotationIntervalSeconds, 5, 30),
             Items = ReadItems()
@@ -80,6 +82,7 @@ public sealed partial class BulletinStore
 
         var configuration = Plugin.Instance.Configuration;
         configuration.VisibleItemCount = Math.Clamp(request.VisibleItemCount, 3, 5);
+        configuration.PanelHeight = NormalizePanelHeight(request.PanelHeight);
         configuration.AutoRotate = request.AutoRotate;
         configuration.RotationIntervalSeconds = Math.Clamp(request.RotationIntervalSeconds, 5, 30);
         configuration.NewsJson = JsonConvert.SerializeObject(request.Items);
@@ -185,5 +188,10 @@ public sealed partial class BulletinStore
         return Path.GetFileName(fileName) == fileName
             && Guid.TryParseExact(Path.GetFileNameWithoutExtension(fileName), "N", out _)
             && extension is ".png" or ".jpg" or ".webp";
+    }
+
+    private static string NormalizePanelHeight(string? value)
+    {
+        return value is "compact" or "tall" ? value : "standard";
     }
 }

--- a/Jellyfin.Plugin.JellyBulletin/Web/bulletin.css
+++ b/Jellyfin.Plugin.JellyBulletin/Web/bulletin.css
@@ -26,6 +26,14 @@
     overflow: hidden;
 }
 
+.bulletin-height-compact .bulletin-feature {
+    height: clamp(13rem, 18vw, 16rem);
+}
+
+.bulletin-height-tall .bulletin-feature {
+    height: clamp(22rem, 32vw, 29rem);
+}
+
 .bulletin-feature.has-image {
     grid-template-columns: minmax(0, 1.25fr) minmax(18rem, .75fr);
 }
@@ -177,6 +185,14 @@
 
     .bulletin-feature {
         height: 27rem;
+    }
+
+    .bulletin-height-compact .bulletin-feature {
+        height: 21rem;
+    }
+
+    .bulletin-height-tall .bulletin-feature {
+        height: 34rem;
     }
 }
 

--- a/Jellyfin.Plugin.JellyBulletin/Web/bulletin.js
+++ b/Jellyfin.Plugin.JellyBulletin/Web/bulletin.js
@@ -89,9 +89,13 @@
         if (!home) return;
 
         const autoRotate = Boolean(data.AutoRotate ?? data.autoRotate ?? true);
+        const requestedPanelHeight = data.PanelHeight ?? data.panelHeight;
+        const panelHeight = requestedPanelHeight === 'compact' || requestedPanelHeight === 'tall'
+            ? requestedPanelHeight
+            : 'standard';
         const rotationSeconds = Math.max(5, Math.min(30,
             Number(data.RotationIntervalSeconds ?? data.rotationIntervalSeconds ?? 9)));
-        const signature = JSON.stringify({ items, autoRotate, rotationSeconds });
+        const signature = JSON.stringify({ items, autoRotate, rotationSeconds, panelHeight });
         const existing = document.getElementById(ROOT_ID);
         if (signature === lastSignature && existing) {
             if (existing.parentElement !== home) home.prepend(existing);
@@ -101,7 +105,7 @@
 
         const root = document.createElement('section');
         root.id = ROOT_ID;
-        root.className = 'jellyfin-bulletin';
+        root.className = `jellyfin-bulletin bulletin-height-${panelHeight}`;
         root.setAttribute('aria-label', 'News');
 
         const feature = document.createElement('div');

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ control.
 - Optional uploaded, pasted, dropped or externally hosted images
 - Image alternative text for accessibility
 - Three to five recent announcements in a compact carousel
+- Compact, standard or tall announcement panel height
 - Configurable automatic rotation with an accessible pause/start control
 - Manual previous and next controls
 - Drag-and-drop ordering and one pinned top announcement

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "JellyBulletin"
 guid: "6ad77d9a-e157-4ca2-82e7-a114f86a5f50"
-version: "0.3.14.0"
+version: "0.3.15.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "News and announcements for Jellyfin."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "JellyBulletin"
 guid: "6ad77d9a-e157-4ca2-82e7-a114f86a5f50"
-version: "0.3.13.0"
+version: "0.3.14.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "News and announcements for Jellyfin."
@@ -13,4 +13,4 @@ owner: "SKYNET"
 artifacts:
 - "Jellyfin.Plugin.JellyBulletin.dll"
 - "logo.png"
-changelog: "Preserve lists and paragraphs inside browser-generated rich-text wrapper elements."
+changelog: "Let administrators choose a compact, standard, or tall announcement panel."


### PR DESCRIPTION
## Summary

- Centers the JellyBulletin plugin artwork on a dark 16:9 canvas.
- Adds safe spacing so the logo displays correctly in Jellyfin plugin cards.
- Updates the plugin version to 0.3.15.0.
- Cna now choose size on the bulletinboard

## Validation

- Builds successfully with 0 warnings and 0 errors.
- Jellyfin repository release 0.3.15.0 is already published.