### PR TITLE
Release JellyBulletin 0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to JellyBulletin are documented here.
 
+## 0.3.20.0
+
+- Publish the current text-only, compact two-item, and external image URL features as a stable release.
+- Clarify that File Transformation is required and JellySpotlight placement integration is optional.
+
 ## 0.3.19.0 — Public beta
 
 - Restore HTTP and HTTPS image URLs alongside locally uploaded images.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.19.0</Version>
-    <AssemblyVersion>0.3.19.0</AssemblyVersion>
-    <FileVersion>0.3.19.0</FileVersion>
+    <Version>0.3.20.0</Version>
+    <AssemblyVersion>0.3.20.0</AssemblyVersion>
+    <FileVersion>0.3.20.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.JellyBulletin/Plugin.cs
+++ b/Jellyfin.Plugin.JellyBulletin/Plugin.cs
@@ -20,7 +20,7 @@ public sealed class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     public override string Name => "JellyBulletin";
 
-    public override string Description => "News and announcements for Jellyfin.";
+    public override string Description => "Announcements for Jellyfin Web. Requires File Transformation; JellySpotlight placement integration is optional.";
 
     public override Guid Id => Guid.Parse("6ad77d9a-e157-4ca2-82e7-a114f86a5f50");
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,16 +1,17 @@
 ---
 name: "JellyBulletin"
 guid: "6ad77d9a-e157-4ca2-82e7-a114f86a5f50"
-version: "0.3.15.0"
+version: "0.3.20.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
-overview: "News and announcements for Jellyfin."
+overview: "Announcements for Jellyfin Web. Requires File Transformation."
 description: >
   Publish formatted news for every Jellyfin user. The latest item is expanded
   by default and up to four previous items remain available in the same panel.
+  File Transformation is required. JellySpotlight placement integration is optional.
 category: "General"
 owner: "SKYNET"
 artifacts:
 - "Jellyfin.Plugin.JellyBulletin.dll"
 - "logo.png"
-changelog: "Let administrators choose a compact, standard, or tall announcement panel."
+changelog: "Publish the current beta features as a stable release and clarify required and optional integrations."


### PR DESCRIPTION
## Summary
- publish the current beta feature set as a stable release
- expose required and optional dependencies in plugin metadata
- keep dependency documentation current

## Verification
- Release build succeeds with 0 warnings and 0 errors
- package structure and ZIP integrity verified